### PR TITLE
Profile page

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -16,7 +16,7 @@ function App() {
           )*/}
 				<Switch>
 					<Route exact path={"/"} component={DashboardRoute} />
-					<Route path={"/profile"} component={ProfileRoute} />
+					<Route path={"/profile/:id"} component={ProfileRoute} />
 					<Route component={NotFoundRoute} />
 				</Switch>
 			</main>

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -1,20 +1,28 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import MemberSearch from '../Member/MemberSearch';
-import StateSearch from '../Member/StateSearch';
-import LeaderBoard from '../LeaderBoard/LeaderBoard';
+import React from "react";
+import { Link } from "react-router-dom";
+import MemberSearch from "../Member/MemberSearch";
+import StateSearch from "../Member/StateSearch";
+import LeaderBoard from "../LeaderBoard/LeaderBoard";
 
 function Dashboard(props) {
-  return (
-    <div>
-      <MemberSearch />
-      <StateSearch />
-      <LeaderBoard />
-      <div>
-        <p>What's happening on the floor?</p>
-      </div>
-    </div>
-  );
+	return (
+		<div>
+			{/* member search will render results component on top of dashboard? */}
+			<MemberSearch />
+			{/* State search component modifies its contents based on dropdown selection */}
+			{/* and will show MediumProfiles on the state's representatives */}
+			{/* will need to show many representatives */}
+			{/* or add district filter for representative display (don't display any members until user has filled both state and district dropdowns?) */}
+			<StateSearch />
+			{/* leaderboard shows sets of 3, at first 1 list */}
+			{/* 3 SmallProfiles showing stat related to leaderboard */}
+			{/* show more than one leaderboard in the future */}
+			<LeaderBoard />
+			<div>
+				<p>What's happening on the floor?</p>
+			</div>
+		</div>
+	);
 }
 
 export default Dashboard;

--- a/src/components/Profile/MediumProfile.js
+++ b/src/components/Profile/MediumProfile.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "./profile.css";
 
-function SmallProfile(props) {
+function MediumProfile(props) {
 	return (
 		<div>
 			<img
@@ -18,6 +18,10 @@ function SmallProfile(props) {
 				{props.last_name}
 				{props.suffix} ({props.party})
 			</p>
+			<section className="member-social-media">
+				<p className="phonenum">{props.phone}</p>
+				<p className="faxnum">{props.fax}</p>
+			</section>
 			<section className="stats">
 				<p className="missed_votes_pct">
 					{" "}
@@ -32,4 +36,4 @@ function SmallProfile(props) {
 	);
 }
 
-export default SmallProfile;
+export default MediumProfile;

--- a/src/components/Profile/MediumProfile.js
+++ b/src/components/Profile/MediumProfile.js
@@ -1,5 +1,6 @@
 import React from "react";
-import "./profile.css";
+import { Link } from "react-router-dom";
+import "./Profile.css";
 
 function MediumProfile(props) {
 	return (
@@ -12,24 +13,24 @@ function MediumProfile(props) {
 				}.jpg`}
 			/>
 			<p className="title">{props.short_title}</p>
-			<p className="name">
-				{props.first_name}
-				{props.middle_name}
-				{props.last_name}
-				{props.suffix} ({props.party})
-			</p>
+			<Link to={`/member/${props.id}`} className="name">
+				{props.member.first_name}
+				{props.member.middle_name}
+				{props.member.last_name}
+				{props.member.suffix} ({props.member.party})
+			</Link>
 			<section className="member-social-media">
-				<p className="phonenum">{props.phone}</p>
-				<p className="faxnum">{props.fax}</p>
+				<p className="phonenum">{props.member.phone}</p>
+				<p className="faxnum">{props.member.fax}</p>
 			</section>
 			<section className="stats">
 				<p className="missed_votes_pct">
 					{" "}
-					Missed Voting Opportunities %: {props.missed_votes_pct}
+					Missed Voting Opportunities %: {props.member.missed_votes_pct}
 				</p>
 				<p className="votes_with_party_pct">
 					{" "}
-					Votes with Party %: {props.votes_with_party_pct}
+					Votes with Party %: {props.member.votes_with_party_pct}
 				</p>
 			</section>
 		</div>

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -1,4 +1,5 @@
 import React from "react";
+import "./profile.css";
 
 function Profile(props) {
 	return (
@@ -8,8 +9,7 @@ function Profile(props) {
 					props.member.id
 				}.jpg`}
 			/>
-			{"Image Link"}
-			<p className="title">{props.member.title}</p>
+			<p className="title">{props.member.short_title}</p>
 			<p className="name">
 				{props.member.first_name}
 				{props.member.middle_name}

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -1,5 +1,6 @@
 import React from "react";
-import "./profile.css";
+import { Link } from "react-router-dom";
+import "./Profile.css";
 
 function Profile(props) {
 	return (

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -5,6 +5,8 @@ function Profile(props) {
 	return (
 		<div>
 			<img
+				className="profile-picture"
+				alt="Photo of Congressperson"
 				src={`https://theunitedstates.io/images/congress/225x275/${
 					props.member.id
 				}.jpg`}

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -3,65 +3,73 @@ import { Link } from "react-router-dom";
 import "./Profile.css";
 
 function Profile(props) {
-	return (
-		<div>
-			<img
-				className="profile-picture"
-				alt="Photo of Congressperson"
-				src={`https://theunitedstates.io/images/congress/225x275/${
-					props.member.id
-				}.jpg`}
-			/>
-			<p className="title">{props.member.short_title}</p>
-			<p className="name">
-				{props.member.first_name}
-				{props.member.middle_name}
-				{props.member.last_name}
-				{props.member.suffix} ({props.member.party})
-			</p>
-			<p className="dob">Born: {props.member.date_of_birth}</p>
-			<section className="member-social-media">
-				{/* maybe these should be icons, or just social media widgets or something */}
-				<a
-					className="twitter"
-					src={`https://twitter.com/${props.member.twitter_account}`}
+	if (props.member.first_name) {
+		console.log(props.member.first_name);
+		return (
+			<div>
+				<img
+					className="profile-picture"
+					alt="Photo of Congressperson"
+					src={`https://theunitedstates.io/images/congress/225x275/${
+						props.member.id
+					}.jpg`}
 				/>
-				<a
-					className="youtube"
-					src={`https://youtube.com/${props.member.youtube_account}`}
-				/>
-				<a
-					className="facebook"
-					src={`https://facebook.com/${props.member.facebook_account}`}
-				/>
-				<p className="phonenum">{props.member.phone}</p>
-				<p className="faxnum">{props.member.fax}</p>
-			</section>
-			<section className="stats">
-				<p className="seniority"> Years in Senate: {props.member.seniority}</p>
-				<p className="next_election">
-					{" "}
-					Next Election: {props.member.next_election}
+				<p className="title">{props.member.short_title}</p>
+				<p className="name">
+					{props.member.first_name}
+					{props.member.middle_name}
+					{props.member.last_name}
+					{props.member.suffix} ({props.member.party})
 				</p>
-				<p className="total_votes">
-					{" "}
-					Total Votes Cast: {props.member.total_votes}
-				</p>
-				<p className="missed_votes">
-					{" "}
-					Missed Voting Opportunities:{props.member.missed_votes}
-				</p>
-				<p className="missed_votes_pct">
-					{" "}
-					Missed Voting Opportunities %: {props.member.missed_votes_pct}
-				</p>
-				<p className="votes_with_party_pct">
-					{" "}
-					Votes with Party %: {props.member.votes_with_party_pct}
-				</p>
-			</section>
-		</div>
-	);
+				<p className="dob">Born: {props.member.date_of_birth}</p>
+				<section className="member-social-media">
+					{/* maybe these should be icons, or just social media widgets or something */}
+					<a
+						className="twitter"
+						src={`https://twitter.com/${props.member.twitter_account}`}
+					/>
+					<a
+						className="youtube"
+						src={`https://youtube.com/${props.member.youtube_account}`}
+					/>
+					<a
+						className="facebook"
+						src={`https://facebook.com/${props.member.facebook_account}`}
+					/>
+					<p className="phonenum">{props.member.phone}</p>
+					<p className="faxnum">{props.member.fax}</p>
+				</section>
+				<section className="stats">
+					<p className="seniority">
+						{" "}
+						Years in Senate: {props.member.seniority}
+					</p>
+					<p className="next_election">
+						{" "}
+						Next Election: {props.member.next_election}
+					</p>
+					<p className="total_votes">
+						{" "}
+						Total Votes Cast: {props.member.total_votes}
+					</p>
+					<p className="missed_votes">
+						{" "}
+						Missed Voting Opportunities:{props.member.missed_votes}
+					</p>
+					<p className="missed_votes_pct">
+						{" "}
+						Missed Voting Opportunities %: {props.member.missed_votes_pct}
+					</p>
+					<p className="votes_with_party_pct">
+						{" "}
+						Votes with Party %: {props.member.votes_with_party_pct}
+					</p>
+				</section>
+			</div>
+		);
+	} else {
+		return "";
+	}
 }
 
 export default Profile;

--- a/src/components/Profile/SmallProfile.js
+++ b/src/components/Profile/SmallProfile.js
@@ -13,8 +13,8 @@ function SmallProfile(props) {
 			/>
 			<p className="title">{props.short_title}</p>
 			<p className="name">
-				{props.first_name}
-				{props.middle_name}
+				{props.first_name.charAt(0)}
+				{"."}
 				{props.last_name}
 				{props.suffix} ({props.party})
 			</p>
@@ -22,10 +22,6 @@ function SmallProfile(props) {
 				<p className="missed_votes_pct">
 					{" "}
 					Missed Voting Opportunities %: {props.missed_votes_pct}
-				</p>
-				<p className="votes_with_party_pct">
-					{" "}
-					Votes with Party %: {props.votes_with_party_pct}
 				</p>
 			</section>
 		</div>

--- a/src/components/Profile/SmallProfile.js
+++ b/src/components/Profile/SmallProfile.js
@@ -1,5 +1,6 @@
 import React from "react";
-import "./profile.css";
+import { Link } from "react-router-dom";
+import "./Profile.css";
 
 function SmallProfile(props) {
 	return (
@@ -11,17 +12,17 @@ function SmallProfile(props) {
 					props.member.id
 				}.jpg`}
 			/>
-			<p className="title">{props.short_title}</p>
+			<p className="title">{props.member.short_title}</p>
 			<p className="name">
-				{props.first_name.charAt(0)}
+				{props.member.first_name.charAt(0)}
 				{"."}
-				{props.last_name}
-				{props.suffix} ({props.party})
+				{props.member.last_name}
+				{props.member.suffix} ({props.member.party})
 			</p>
 			<section className="stats">
 				<p className="missed_votes_pct">
 					{" "}
-					Missed Voting Opportunities %: {props.missed_votes_pct}
+					Missed Voting Opportunities %: {props.member.missed_votes_pct}
 				</p>
 			</section>
 		</div>

--- a/src/components/Profile/SmallProfile.js
+++ b/src/components/Profile/SmallProfile.js
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import "./Profile.css";
 
 function SmallProfile(props) {
+	console.log(props.member.first_name);
+	let firstInitial = props.member.first_name.charAt(0);
 	return (
 		<div>
 			<img
@@ -14,7 +16,7 @@ function SmallProfile(props) {
 			/>
 			<p className="title">{props.member.short_title}</p>
 			<p className="name">
-				{props.member.first_name.charAt(0)}
+				{firstInitial}
 				{"."}
 				{props.member.last_name}
 				{props.member.suffix} ({props.member.party})

--- a/src/routes/ProfileRoute.js
+++ b/src/routes/ProfileRoute.js
@@ -12,20 +12,20 @@ export default class ProfileRoute extends Component {
 			member: {}
 		};
 	}
-	componentDidMount() {
+	async componentDidMount() {
 		let memberID = this.props.match.params.id;
-		MemberApiService.getMemberbyID(memberID).then(member =>
+		await MemberApiService.getMemberbyID(memberID).then(member =>
 			this.setState({ member })
 		);
 	}
 	render() {
-		return this.state.member ? (
+		return !this.state.member ? (
 			"Now Loading..."
 		) : (
 			<section className="member-profile-container">
 				<Profile member={this.state.member} />
 				<MediumProfile member={this.state.member} />
-				<SmallProfile member={this.state.member} />
+				{/* <SmallProfile member={this.state.member} /> */}
 			</section>
 		);
 	}

--- a/src/routes/ProfileRoute.js
+++ b/src/routes/ProfileRoute.js
@@ -1,6 +1,8 @@
 import React, { Component } from "react";
-import Profile from "../components/Profile/Profile";
+
 import MemberApiService from "../services/member-api-service";
+import Profile from "../components/Profile/Profile";
+import MediumProfile from "../components/Profile/MediumProfile";
 import SmallProfile from "../components/Profile/SmallProfile";
 
 export default class ProfileRoute extends Component {

--- a/src/routes/ProfileRoute.js
+++ b/src/routes/ProfileRoute.js
@@ -14,7 +14,7 @@ export default class ProfileRoute extends Component {
 	}
 	componentDidMount() {
 		let memberID = this.props.match.params.id;
-		MemberApiService.getMember(memberID).then(member =>
+		MemberApiService.getMemberbyID(memberID).then(member =>
 			this.setState({ member })
 		);
 	}

--- a/src/routes/ProfileRoute.js
+++ b/src/routes/ProfileRoute.js
@@ -11,8 +11,8 @@ export default class ProfileRoute extends Component {
 		};
 	}
 	componentDidMount() {
-		// potentially pass down member id or name here from the link sending us to this page?
-		MemberApiService.getMember(`------`).then(member =>
+		let memberID = this.props.match.params.id;
+		MemberApiService.getMember(memberID).then(member =>
 			this.setState({ member })
 		);
 	}
@@ -22,6 +22,7 @@ export default class ProfileRoute extends Component {
 		) : (
 			<section className="member-profile-container">
 				<Profile member={this.state.member} />
+				<MediumProfile member={this.state.member} />
 				<SmallProfile member={this.state.member} />
 			</section>
 		);

--- a/src/routes/ProfileRoute.js
+++ b/src/routes/ProfileRoute.js
@@ -12,9 +12,9 @@ export default class ProfileRoute extends Component {
 			member: {}
 		};
 	}
-	async componentDidMount() {
+	componentDidMount() {
 		let memberID = this.props.match.params.id;
-		await MemberApiService.getMemberbyID(memberID).then(member =>
+		MemberApiService.getMemberbyID(memberID).then(member =>
 			this.setState({ member })
 		);
 	}

--- a/src/services/member-api-service.js
+++ b/src/services/member-api-service.js
@@ -1,7 +1,7 @@
 import config from "../config";
 
 const MemberApiService = {
-	getMember(id) {
+	getMember(id, house) {
 		let getEndpoint =
 			"https://api.propublica.org/congress/v1/{congress}/{chamber}/members.json";
 		return fetch(getEndpoint + id, {

--- a/src/services/member-api-service.js
+++ b/src/services/member-api-service.js
@@ -2,7 +2,7 @@ import config from "../config";
 
 const MemberApiService = {
 	getMemberbyID(id) {
-		return fetch(`localhost:8000/api/members/${id}`).then(res =>
+		return fetch(`http://localhost:8000/api/members/${id}`).then(res =>
 			!res.ok ? res.json().then(e => Promise.reject(e)) : res.json()
 		);
 	},

--- a/src/services/member-api-service.js
+++ b/src/services/member-api-service.js
@@ -1,15 +1,20 @@
 import config from "../config";
 
 const MemberApiService = {
-	getMember(id, house) {
-		let getEndpoint =
-			"https://api.propublica.org/congress/v1/{congress}/{chamber}/members.json";
-		return fetch(getEndpoint + id, {
-			headers: {}
-		}).then(res =>
+	getMemberbyID(id) {
+		return fetch(`localhost:8000/api/members/${id}`).then(res =>
 			!res.ok ? res.json().then(e => Promise.reject(e)) : res.json()
 		);
 	},
+	// getMember(id) {
+	// 	let getEndpoint =
+	// 		"https://api.propublica.org/congress/v1/{congress}/{chamber}/members.json";
+	// 	return fetch(getEndpoint + id, {
+	// 		headers: {}
+	// 	}).then(res =>
+	// 		!res.ok ? res.json().then(e => Promise.reject(e)) : res.json()
+	// );
+	// },
 
 	getSenators(state) {
 		// 'https://api.propublica.org/congress/v1/members/{chamber}/{state}/{district}/current.json';


### PR DESCRIPTION
profile pages now load with member info, photo from open external API


member data is passed down from ProfileRoute

Medium and Small are listed in this file for development purposes
medium: dashboard
small: leaderboard

current issue:
all profile views will start loading with a partial set of props before reloading with a full set.
current bypass is if() conditional requiring specific prop to be in state before rendering